### PR TITLE
seo: enable jekyll-seo-tag, replace upstream README and About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,20 @@
-<div align="center">
-  <br>
-  <img src="/images/reverie-text.png" alt="Reverie" width="200"/>
-  <br>  
-  <p align="center">
-    <i>Support my work via <a href="https://paypal.me/AmitMerchant">Paypal</a></i>
-    •
-    <i>Would you be interested in <a href="https://www.producthunt.com/upcoming/reverie-pro">Reverie Pro</a>?</i>
-  </p>
-</div>
+# qte77.github.io
 
----
+Personal blog — live at [qte77.github.io](https://qte77.github.io).
 
-Reverie is a [Jekyll](https://jekyllrb.com/)-powered theme which is simple and opinionated. It's actually a fork of [jekyll-now](https://github.com/barryclark/jekyll-now) with some additional features and personal touches which I've implemented to suit my needs for my blog.
+Notes on AI agents, ML, evaluation, GitHub Actions, and lab automation —
+accompanying the work at [github.com/qte77](https://github.com/qte77).
 
-> [Theme demo](https://reverie-jekyll.netlify.app/)
+## Build
 
-This is a plug-and-play Jekyll theme best suited to use on [GitHub Pages](https://pages.github.com) (or [Cloudflare Pages](https://pages.cloudflare.com/) if you want to have your repository private) without even setting up a local environment.
+Standard Jekyll on GitHub Pages. To preview locally:
 
-![](/images/reverie-demo.png)
-
-|  Responsiveness            |  Search | Categories |
-|---------------------|----------------------|----------------------|
-|![Responsiveness](/images/mobile-demo.png) | ![search](/images/search.png) | ![categories](/images/categories.png) |
-
-# Table of Contents
-  - [Features overview](#features-overview)
-  - [Using Reverie on GitHub Pages](#using-reverie-on-github-pages)
-    - [1. Fork Reverie to your User Repository](#1-fork-reverie-to-your-user-repository)
-    - [2. Customize and view your site](#2-customize-and-view-your-site)
-    - [3. Publish your first blog post](#3-publish-your-first-blog-post)
-  - [Using Categories in Reverie](#using-categories-in-reverie)
-  - [Pagination](#pagination)
-  - [RSS](#rss)
-  - [Sitemap](#sitemap)
-  - [Emailware](#emailware)
-  - [The name?](#the-name)
-  - [License](#license)
-
-## Features overview
-
-- Clean and minimal design
-- Single column post layout
-- Command-line free fork-first workflow, using GitHub.com to create, customize and post to your blog
-- Fully responsive and mobile optimized theme
-- Sass/Coffeescript support using Jekyll 2.0
-- Free hosting on your GitHub Pages user site
-- All the SEO goodies come built-in
-- Markdown blogging
-- Supports [Pullquotes](https://reverie-jekyll.netlify.app/pullquotes/)
-- Syntax highlighting using Pygments
-    - [Dracula syntax theme](https://draculatheme.com/) included
-- Disqus commenting
-- Social media icons
-- Google Analytics integration
-- Supports [Google Analytics 4](https://support.google.com/analytics/answer/10089681?hl=en)
-- Fuzzy search across blog posts
-- Blog with pagination
-- Categorize posts out-of-the box
-- RSS Feed
-- Built-in sitemap
-
-> <p><i>Like this theme?</i> If so, consider donating a small amount that will help my maintaining this project further.<p>
-> You can support me via <a href="https://paypal.me/AmitMerchant">Paypal</a>.
-
-## Using Reverie on GitHub Pages
-
-Setting up Reverie on GitHub Pages is as simple as it gets!
-
-### 1. Fork Reverie to your User Repository
-
-Fork this repository, then rename the repository to `yourgithubusername.github.io`.
-
-Alternatively, you can click the [`Use this template`](https://github.com/amitmerchant1990/reverie/generate) button if you want to create a repository with a clean commit history which will use Reverie as a template.
-
-Your Jekyll blog will often be viewable immediately at <https://yourgithubusername.github.io> (if it's not, you can often force it to build by completing step 2).
-
-### 2. Customize and view your site
-
-Enter your site name, description, avatar and many other options by editing the `_config.yml` file. You can easily turn on Google Analytics tracking, Disqus commenting and social icons here.
-
-Making a change to `_config.yml` (or any file in your repository) will force GitHub Pages to rebuild your site with Jekyll. Your rebuilt site will be viewable a few seconds later at <https://yourgithubusername.github.io> - if not, give it ten minutes as GitHub suggests and it'll appear soon.
-
-### 3. Publish your first blog post
-
-Delete all files from `_posts`directory and create a new file called `/_posts/2019-2-13-Hello-World.md` to publish your first blog post. That's all you need to do to publish your first blog post! This [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) might come in handy while writing the posts.
-
-> You can add additional posts in the browser on GitHub.com too! Just hit the <kbd>Create new file</kbd> button in `/_posts/` to create new content. Just make sure to include the [front-matter](http://jekyllrb.com/docs/frontmatter/) block at the top of each new blog post and make sure the post's filename is in this format: year-month-day-title.md
-
-## Using Categories in Reverie
-
-You can categorize your content based on `categories` in Reverie. For this, you just need to add `categories` in front matter like below:
-
-For adding single category:
-
-```md
-categories: JavaScript
+```bash
+bundle install
+bundle exec jekyll serve
 ```
 
-For adding multiple categories:
+## Theme
 
-```md
-categories: [PHP, Laravel]
-```
-
-The categorized content can be shown over this URL: <https://yourgithubusername.github.io/categories/>
-
-## Pagination
-
-Pagination of posts in Reverie works out-of-the-box. You only need to specify the number of posts you want on a single page in `_config.yml` and Reverie will take care of the rest.
-
-```yml
-paginate: 6
-```
-
-## RSS
-
-Reverie comes with a [RSS feed](https://en.wikipedia.org/wiki/RSS) in-built. The generated RSS Feed of your blog can be found at <https://yourgithubusername.github.io/feed>. You can see the example RSS feed over [here](https://reverie-jekyll.netlify.app/feed.xml).
-
-## Sitemap
-
-The generated sitemap of your blog can be found at <https://yourgithubusername.github.io/sitemap.xml>. You can see the example sitemap feed over [here](https://reverie-jekyll.netlify.app/sitemap.xml).
-
-## Emailware
-Reverie is an [emailware](https://en.wiktionary.org/wiki/emailware). Meaning, if you liked using this theme or it has helped you in any way, I'd like you send me an email at <bullredeyes@gmail.com> about anything you'd want to say about this software. I'd really appreciate it!
-
-## The name?
-
-reverie - _a state of being pleasantly lost in one's thoughts; a daydream._<br><sup>/ˈrɛv(ə)ri/</sup> 
-
-
-## License
-
-MIT
+Built on [Reverie](https://github.com/amitmerchant1990/reverie) (MIT) — a
+fork-friendly Jekyll theme by [Amit Merchant](https://www.amitmerchant.com).

--- a/_config.yml
+++ b/_config.yml
@@ -10,8 +10,9 @@ name: Recap on ML
 # Name of the author
 author: qte77
 
-# Short bio or description (displayed in the header)
-description: Recap on ML
+# Short bio or description (displayed in the header AND used as SEO meta description)
+description: Notes on AI agents, ML, and dev tooling — by qte77
+lang: en
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://avatars.githubusercontent.com/u/93844790?v=4 #/images/reverie.png
@@ -86,7 +87,7 @@ sass:
 plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
-  # - jekyll-seo-tag
+  - jekyll-seo-tag # JSON-LD + canonical + OG tags; layout already calls {% seo %}
   - jekyll-paginate
 
 include: ['_pages']

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,5 +4,26 @@ title: About
 permalink: /about/
 ---
 
-- [Sitemap](https://{{ site.footer-links.github }}.github.io/sitemap.xml)
-- [RSS](https://{{ site.footer-links.github }}.github.io/feed)
+I'm **qte77**. I build agentic dev infrastructure, reusable GitHub Actions,
+document pipelines, and lab automation. This blog publishes notes from that
+work.
+
+## Where to find things
+
+- **Framework** — [qte77/qte77](https://github.com/qte77/qte77): polyrepo
+  orchestration framework for AI coding agents. Authority chain, governance,
+  goals, learnings.
+- **Orchestrator** — [polyforge-orchestrator](https://github.com/qte77/polyforge-orchestrator):
+  coordinates parallel Claude Code agents across the polyrepo.
+- **Plugins** — [claude-code-plugins](https://github.com/qte77/claude-code-plugins):
+  25 plugins, 60 skills, 2 agents — extracted from production workflows.
+- **All repos** — [github.com/qte77](https://github.com/qte77).
+
+## Topics here
+
+ML · agents · evaluation · Python · GitHub Actions · lab automation · Claude Code
+
+## Subscribe
+
+- [RSS](/feed.xml)
+- [Sitemap](/sitemap.xml)


### PR DESCRIPTION
## Summary
- Uncomment `jekyll-seo-tag` in `_config.yml` (layout already calls `{% seo %}`)
- Improve site `description` for SEO meta + add `lang: en`
- Replace upstream Reverie README boilerplate (had a third-party PayPal link, no project context)
- Rewrite About page with a real bio + ecosystem links (was a bare RSS/sitemap stub)

## Why
Three weakest signals on the site right now: (a) no JSON-LD or canonical tags emitted, (b) README sells someone else's project, (c) /about/ tells visitors nothing. This PR fixes all three with minimal surface area.

## Out of scope (next PRs)
- Favicon replacement (needs offline image conversion of brand wordmark → \`images/favicon-32x32.png\`)
- llms.txt, social previews, schema.org Person — deferred pending discussion

## Test plan
- [ ] GitHub Pages build succeeds
- [ ] view-source on a post shows JSON-LD BlogPosting and canonical tag
- [ ] Homepage header still renders (uses site.description)
- [ ] /about/ renders with new content
- [ ] No broken internal links