### PR TITLE
chore: bump lychee-action (security) + fix sass linter warnings

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -16,10 +16,10 @@ jobs:
   linkChecker:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
 
       - name: "Link Checker"
-        uses: "lycheeverse/lychee-action@v1.4.1"
+        uses: "lycheeverse/lychee-action@v2.0.2"
         with:
           fail: true
         env:

--- a/_sass/_darcula.scss
+++ b/_sass/_darcula.scss
@@ -1,5 +1,6 @@
 .highlight {
-    background-color: #1e1c3f;
+    background: #282a36;
+    color: #f8f8f2;
     padding: 7px 7px 7px 10px;
     overflow: auto;
     font-size: 95%;
@@ -10,14 +11,13 @@ code {
     color: #d8d8d8;
 }
 
-.highlighter-rouge { 
-    background-color: #FAFAFA; 
-    color: #FF554A; 
+.highlighter-rouge {
+    background-color: #FAFAFA;
+    color: #FF554A;
     font-size: 16px;
 }
 
 .highlight .hll { background-color: #f1fa8c }
-.highlight  { background: #282a36; color: #f8f8f2 }
 .highlight .c { color: #6272a4 } /* Comment */
 .highlight .err { color: #f8f8f2 } /* Error */
 .highlight .g { color: #f8f8f2 } /* Generic */

--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -19,7 +19,6 @@ time, mark, audio, video {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	font-size: 100%;
 	font: inherit;
 	vertical-align: baseline;
 }


### PR DESCRIPTION
## Summary
Two topic commits on one branch:

1. **chore(deps)** — Bump \`lycheeverse/lychee-action@v1.4.1\` → \`@v2.0.2\` (closes Dependabot alert #1 / CVE-2024-48908 / GHSA-65rg-554r-9j5x). Also \`actions/checkout@v3\` → \`@v4\` (v3 deprecated).
2. **style(sass)** — Fix two Reverie sass linter warnings: duplicate \`.highlight\` selector in \`_darcula.scss\`, and redundant \`font-size: 100%\` before \`font: inherit\` in \`_reset.scss\`.

## Why
Security alert + ongoing CodeFactor noise. Both are surface-level fixes; no behavior change expected.

## Test plan
- [ ] CodeFactor passes (the two sass warnings should clear)
- [ ] Links-fail-fast workflow still runnable (no schema breakage)
- [ ] Syntax highlighting still renders (visually identical — same final cascade)
- [ ] Meyer reset still applies (font inheritance unchanged)