### PR TITLE
docs(readme): 'Personal blog' → 'Account blog'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qte77.github.io
 
-Personal blog — live at [qte77.github.io](https://qte77.github.io).
+Account blog — live at [qte77.github.io](https://qte77.github.io).
 
 Notes on AI agents, ML, evaluation, GitHub Actions, and lab automation —
 accompanying the work at [github.com/qte77](https://github.com/qte77).


### PR DESCRIPTION
One-line wording fix. Matches the account-wide framing of the qte77/qte77 README (account vision, not personal profile).