### PR TITLE
feat(seo): SVG favicon + Person schema on /about/

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,7 @@
     <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
 
     <meta name="theme-color" content="#000000">
+    <link rel="icon" type="image/svg+xml" href="{{ site.baseurl }}/assets/favicon.svg">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/images/favicon-32x32.png">
     {% include analytics_head.html %}
   </head>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -27,3 +27,24 @@ ML · agents · evaluation · Python · GitHub Actions · lab automation · Clau
 
 - [RSS](/feed.xml)
 - [Sitemap](/sitemap.xml)
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "qte77",
+  "url": "https://qte77.github.io",
+  "sameAs": [
+    "https://github.com/qte77"
+  ],
+  "knowsAbout": [
+    "AI agents",
+    "agent evaluation",
+    "agentic development",
+    "Claude Code",
+    "GitHub Actions",
+    "lab automation",
+    "machine learning"
+  ]
+}
+</script>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-label="qte77 mark">
+  <style>
+    .mark-bg { fill: #0d1117; }
+    .mark-fg { fill: #e6edf3; }
+    .mark-accent { fill: #388bfd; }
+    @media (prefers-color-scheme: light) {
+      .mark-bg { fill: #ffffff; }
+      .mark-fg { fill: #1f2328; }
+      .mark-accent { fill: #1f6feb; }
+    }
+  </style>
+  <rect class="mark-bg" x="0" y="0" width="80" height="80" rx="12" />
+  <g><path d="M383 561Q383 399 437.0 307.0Q491 215 586 215Q681 215 736.0 307.0Q791 399 791 561Q791 723 736.0 815.0Q681 907 586 907Q491 907 437.0 815.0Q383 723 383 561ZM791 158Q737 64 665.5 17.5Q594 -29 504 -29Q305 -29 197.5 123.0Q90 275 90 559Q90 839 196.0 993.0Q302 1147 494 1147Q595 1147 669.5 1098.0Q744 1049 791 952V1120H1083V-426H791Z" transform="translate(14.7126,47.2900) scale(0.013672,-0.013672)" class="mark-fg" /><path d="M135 1493H1079V1284L573 0H272L758 1233H135Z" transform="translate(31.5700,47.2900) scale(0.013672,-0.013672)" class="mark-fg" /></g><rect class="mark-accent" x="48.43" y="44.29" width="16.86" height="3" rx="1.5" />
+</svg>


### PR DESCRIPTION
## Summary
Two topic commits closing out the SEO/GEO baseline:

1. **feat(seo) favicon** — replace upstream Reverie default with the qte77 wordmark mark SVG (copied from \`qte77/qte77/brand/images/logo-mark.paths.dejavu.svg\`). Theme-aware via inline \`prefers-color-scheme\` CSS. PNG fallback preserved.
2. **feat(seo) Person schema** — inline schema.org \`Person\` JSON-LD on \`/about/\` with \`sameAs\` → GitHub. AI engines (Claude, ChatGPT, Perplexity) use this for entity disambiguation when answering 'who is qte77'.

## Test plan
- [ ] Favicon renders in browser tab (dark + light)
- [ ] \`/about/\` rendered HTML contains the JSON-LD script tag
- [ ] Google Rich Results test passes for the Person schema