### PR TITLE
feat(seo): robots.txt with Sitemap directive

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://qte77.github.io/sitemap.xml


### PR DESCRIPTION
One-line SEO fix: search engines auto-discover /sitemap.xml on crawl instead of requiring manual Google Search Console submission. Allow-all (static blog, no sensitive paths).