### PR TITLE
ci(llms-txt): auto-generate llms.txt via gha-llms-txt-action

### DIFF
--- a/.github/templates/llms.txt.tpl
+++ b/.github/templates/llms.txt.tpl
@@ -1,0 +1,28 @@
+# ${PROJECT_NAME}
+
+> ${PROJECT_DESC}
+
+## About
+
+- [About](${BLOB}/_pages/about.md): owner, ecosystem map, topics
+- [README](${BLOB}/README.md): repo metadata, theme attribution
+
+## Featured posts
+
+- [A $150 Pipetting Robot from a Stock 3D Printer](${BLOB}/_posts/2026-06-01-pipettebot-sub-150-pipetting-robot.md): cheap lab automation via Anycubic i3 + DLAB dPette+, PC-as-host, Apache-2.0
+- [GraphJudge — Measuring How Agents Collaborate](${BLOB}/_posts/2026-01-15-agentx-agentbeats-writeup.md): AgentBeats competition entry, graph-based MAS coordination assessment
+- [AI Agents-eval — Comprehensive Analysis](${BLOB}/_posts/2025-08-09-ai-agents-eval-comprehensive-analysis.md): research MAS evaluation framework on PeerRead
+- [AI Agents-eval — Papers Meta Review](${BLOB}/_posts/2025-08-09-ai-agents-eval-papers-meta-review.md): meta-review across 50+ agent evaluation papers
+- [AI Agents-eval — Enhancement Recommendations](${BLOB}/_posts/2025-08-09-ai-agents-eval-enhancement-recommendations.md): forward-looking improvements
+
+## Subscribe
+
+- RSS: https://qte77.github.io/feed.xml
+- Sitemap: https://qte77.github.io/sitemap.xml
+
+## Author
+
+- GitHub: https://github.com/qte77
+- Framework: https://github.com/qte77/qte77
+- Polyforge orchestrator: https://github.com/qte77/polyforge-orchestrator
+- Claude Code plugins: https://github.com/qte77/claude-code-plugins

--- a/.github/workflows/llms-txt.yaml
+++ b/.github/workflows/llms-txt.yaml
@@ -1,0 +1,65 @@
+---
+# Auto-generate /llms.txt from .github/templates/llms.txt.tpl via the
+# qte77/gha-llms-txt-action composite action. Triggers on changes to the
+# template, the README headline (${PROJECT_NAME}), and the workflow itself.
+# Manual workflow_dispatch supported.
+#
+# The action validates every ${BLOB}/path link points to an existing file,
+# substitutes ${BLOB} / ${PROJECT_NAME} / ${PROJECT_DESC} via envsubst,
+# writes /llms.txt at repo root, and (this workflow) opens an auto/llms-txt-
+# update-* PR against master when the rendered output drifts from disk.
+#
+# Action pin: qte77/gha-llms-txt-action@v0.1.0 ->
+#   commit 7cb4f03bd69a23c0e561ce76e926cadc0d3d3b9f.
+# create_pr=false is set on the action because its built-in PR step
+# hardcodes --base main; we open the PR ourselves against master.
+
+name: llms-txt
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - ".github/templates/llms.txt.tpl"
+      - ".github/workflows/llms-txt.yaml"
+      - "README.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: llms-txt
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: regenerate llms.txt from template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - id: llms
+        uses: qte77/gha-llms-txt-action@7cb4f03bd69a23c0e561ce76e926cadc0d3d3b9f  # v0.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          output_path: llms.txt
+          default_branch: master
+          create_pr: false
+
+      - name: Open PR against master
+        if: steps.llms.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          BRANCH="auto/llms-txt-update-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git add llms.txt
+          git commit -m "docs: update llms.txt"
+          git push -u origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "docs: update llms.txt" \
+            --body "Auto-generated llms.txt update by [qte77/gha-llms-txt-action](https://github.com/qte77/gha-llms-txt-action)."


### PR DESCRIPTION
## Summary
Adopt the canonical qte77 llms.txt pattern (analyze-stock-kpi, doc-pipeline-engine):

- **Template** at \`.github/templates/llms.txt.tpl\` — envsubst variables, validated \`\${BLOB}\` links, curated featured posts + RSS/sitemap/author
- **Workflow** \`.github/workflows/llms-txt.yaml\` — calls \`qte77/gha-llms-txt-action@7cb4f03\` (v0.1.0), regenerates \`/llms.txt\` on changes to template / README / workflow, opens auto-PR against \`master\`

## Why
The user clarified earlier that llms.txt has higher value on the plugins repo than the blog; this PR adds it to the blog too with auto-regeneration so it stays current as posts land. The composite action also validates every \`\${BLOB}\` link points to an existing file — stale links can't accumulate.

## Pattern divergence from analyze-stock-kpi
- \`output_path: llms.txt\` (root) instead of \`docs/llms.txt\` — llms.txt convention is repo root for sites
- \`default_branch: master\` — our repo uses master, not main
- \`create_pr: false\` + custom PR step — the action hardcodes \`gh pr create --base main\` which would fail here

## Pre-conditions already in place this PR
- \`allowed_actions: selected\` allowlist already extended to include \`qte77/gha-llms-txt-action@*\`
- Workflow token \`contents: write\` + \`pull-requests: write\` (privileged but pinned actions + own-org reusable)

## Test plan
- [ ] First run on merge generates \`/llms.txt\` and opens an auto/llms-txt-update-* PR
- [ ] Generated llms.txt is reachable at \`https://qte77.github.io/llms.txt\` after the auto-PR is merged
- [ ] Validation step rejects stale \`\${BLOB}\` links if a featured post file is removed