### PR TITLE
blog: agent-loop post + post excerpts + front-matter fixes

### DIFF
--- a/_posts/2022-07-01-ml-transformer-distiled-1.md
+++ b/_posts/2022-07-01-ml-transformer-distiled-1.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Transformer distiled, Part 1 of 2
-excerpt: 
+excerpt: An overview of the core mathematical components of the Transformer architecture, covering scaled dot-product attention, softmax, multi-head attention, linear layers, and learned embeddings.
 categories: [ml, theory, transformer, dot-product, softmax, attention, linear, embedding]
 ---
 

--- a/_posts/2022-07-15-static-sites-jekyll-sphinx-readthedocs.md
+++ b/_posts/2022-07-15-static-sites-jekyll-sphinx-readthedocs.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Static-sites on GH-Pages
-excerpt: 
+excerpt: A reference survey of static-site options for GitHub Pages, comparing small and full Jekyll themes, Gatsby, Sphinx, and ReadTheDocs with links to each tool.
 categories: [statis-sites, gh-pages, jekyll, sphinx, readthedocs, github.io]
 ---
 

--- a/_posts/2022-08-01-ml-transformer-distiled-2.md
+++ b/_posts/2022-08-01-ml-transformer-distiled-2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Transformer distiled, Part 2 of 2
-excerpt: 
+excerpt: Part two of the Transformer deep-dive, covering regularization, the distinction between self-attention and cross-attention, and the choice between adding and concatenating positional encodings.
 categories: [ml, theory, transformer, regularization, attention, embedding, encoding]
 ---
 

--- a/_posts/2022-08-08-python-iterator-generator.md
+++ b/_posts/2022-08-08-python-iterator-generator.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Python Iterators and Generators
-excerpt: 
+excerpt: A concise reference on Python iterators and generators — the protocol-based lazy-evaluation primitives underpinning memory-efficient iteration in Python.
 categories: [python, iterator, generator]
 ---
 

--- a/_posts/2022-08-15-ml-covar-shift-inductive-priors.md
+++ b/_posts/2022-08-15-ml-covar-shift-inductive-priors.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Covariance Shift and Inductive Priors
-excerpt:
+excerpt: An outline of covariance shift and inductive priors in machine learning, touching on regularization techniques including dropout, label smoothing, and the distinction between regularization and normalization.
 categories: [ml, theory, covariance shift, inductive priors]
 ---
 

--- a/_posts/2022-08-22-python-matmul-vs-einsum.md
+++ b/_posts/2022-08-22-python-matmul-vs-einsum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Python matmul() vs einsum()
-excerpt: 
+excerpt: A comparison of Python's matmul operator and NumPy/PyTorch einsum for tensor contraction, covering theoretical background and practical case studies relevant to ML workloads.
 categories: [python, matmul, einsum, functions, ml]
 ---
 

--- a/_posts/2022-09-01-ml-transfomer-pro-con.md
+++ b/_posts/2022-09-01-ml-transfomer-pro-con.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Transformer pro and contra
-excerpt: 
+excerpt: A structured look at Transformer trade-offs, examining quadratic time/space complexity, O(1) path length, parallelization advantages, and the role of transfer learning and pre-training.
 categories: [ml, theory, transformer, pro vs con, complexity, TIME, SPACE, path length, parallelization, transfer learning, pre-training]
 ---
 

--- a/_posts/2022-09-08-python-futures.md
+++ b/_posts/2022-09-08-python-futures.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Python Futures
-excerpt: 
+excerpt: A reference post on Python Futures — the concurrent.futures abstraction for managing asynchronous execution of callables across threads and processes.
 categories: [python, futures]
 ---
 

--- a/_posts/2023-08-06-SegFormer-Part0-Quantization-ShortIntroReason.md
+++ b/_posts/2023-08-06-SegFormer-Part0-Quantization-ShortIntroReason.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  SegFormer Quantization Part 1 Short Intro and Reason
-excerpt: 
+excerpt: Introduction to a series on quantizing the pre-trained SegFormer vision transformer, outlining the goal of reducing model size via 8-bit/4-bit and custom quantization using HuggingFace, PyTorch, and bitsandbytes.
 categories: [ml, theory, transformer, attention, embedding, encoding, tensor, quantization]
 ---
 

--- a/_posts/2024-05-05-SegFormer-Part1-Description.md
+++ b/_posts/2024-05-05-SegFormer-Part1-Description.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  SegFormer Part 1, Description
-excerpt: 
+excerpt: Describes the SegFormer setup for semantic segmentation fine-tuning on the MIT ADE20k scene-parsing dataset, detailing the Trainer execution order from on-the-fly transforms through metric computation.
 categories: [writeup, transformer, segformer, description]
 ---
 

--- a/_posts/2024-05-05-SegFormer-Part2-PoC-Difficulties.md
+++ b/_posts/2024-05-05-SegFormer-Part2-PoC-Difficulties.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  SegFormer Part 2, PoC Difficulties and Errors
-excerpt: 
+excerpt: A log of errors and solutions encountered building a SegFormer PoC notebook, covering label-count mismatches, CUDA out-of-memory errors, device-map issues, and collator bugs during training.
 categories: [writeup, transformer, segformer, difficulties, errors]
 ---
 

--- a/_posts/2024-05-05-SegFormer-Part3-Quantization-Description.md
+++ b/_posts/2024-05-05-SegFormer-Part3-Quantization-Description.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  SegFormer Part 3, Quantization Description
-excerpt: 
+excerpt: Describes quantization approaches for SegFormer, covering bitsandbytes 8-bit and NF4 4-bit configurations via BitsAndBytesConfig, and links to HuggingFace, PyTorch, and DeepSpeed quantization resources.
 categories: [writeup, transformer, segformer, quantization, description]
 ---
 

--- a/_posts/2024-05-05-SegFormer-Part4-Quantization-Difficulties-Part1.md
+++ b/_posts/2024-05-05-SegFormer-Part4-Quantization-Difficulties-Part1.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  SegFormer Part 4, Quantization Difficulties and Errors Part 1
-excerpt: 
+excerpt: Documents runtime errors encountered while loading and training quantized SegFormer models, including device_map incompatibilities, half-precision input mismatches, and bitsandbytes 8-bit training failures.
 categories: [writeup, transformer, segformer, quantization, difficulties, errors]
 ---
 

--- a/_posts/2024-05-27-ML-Tooling.md
+++ b/_posts/2024-05-27-ML-Tooling.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  Collection of Tools for ML
+excerpt: A curated reference list of ML tooling spanning end-to-end AutoML frameworks, EDA libraries, feature engineering tools, hyperparameter tuners, experiment trackers, and exploratory runtimes.
 categories: [ml, tools]
 ---
 

--- a/_posts/2024-06-08-SegFormerBaseline-FineTuning-results.md
+++ b/_posts/2024-06-08-SegFormerBaseline-FineTuning-results.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title: SegFormer Baseline Fine-Tuning Results
+excerpt: Benchmark results for fine-tuning and half-precision SegFormer (mit-b0) on scene_parse_150, comparing original, fine-tuned, and float16 model variants across IoU and accuracy metrics on GPU T4 and P100.
+categories: [writeup, segformer, quantization, results]
+---
+
 # Resultes fine-tuning pre-trained SegFormer
 
 - [SegFormer-fine-tune-half-baseline.py](https://github.com/qte77/SegFormerQuantization/edit/main/PoC/SegFormer-fine-tune-half-baseline.py)

--- a/_posts/2025-02-07-ai-agents-tools-list.md
+++ b/_posts/2025-02-07-ai-agents-tools-list.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: AI Agents Tools List
-excerpt: 
+excerpt: A categorized reference list of AI agent frameworks, research agents, benchmarking tools, execution tracers, and AI-enhanced workflow platforms available as of early 2025.
 categories: [ml, ai, agents, tools,list]
 ---
 

--- a/_posts/2025-02-07-ai-coding-tools-list.md
+++ b/_posts/2025-02-07-ai-coding-tools-list.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  AI Coding Tools List
-excerpt: 
+excerpt: A reference list of AI-assisted coding tools covering bug search, IDE and terminal integrations, infrastructure provisioning, full-stack builders, and UI development assistants as of early 2025.
 categories: [ml, ai, coding, tools, list]
 ---
 

--- a/_posts/2025-08-09-ai-agents-eval-comprehensive-analysis.md
+++ b/_posts/2025-08-09-ai-agents-eval-comprehensive-analysis.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: AI Agents-eval Comprehensive Analysis
-excerpt: 
+excerpt: Per-paper summaries of 50+ agent evaluation research papers from 2023 to 2025, assessing each work's evaluation approach, focus area, relevance to the Agents-eval project, and a concrete integration example.
 categories: [ml, ai, agents, eval]
 ---
 

--- a/_posts/2025-08-09-ai-agents-eval-enhancement-recommendations.md
+++ b/_posts/2025-08-09-ai-agents-eval-enhancement-recommendations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: AI Agents-eval Enhancement Recommendations
-excerpt: 
+excerpt: A prioritized roadmap of twelve proposed enhancements for the Agents-eval project, spanning multi-dimensional evaluation architecture, safety-first modules, predictive evaluation, and AgentOps integration.
 categories: [ml, ai, agents, eval]
 ---
 

--- a/_posts/2025-08-09-ai-agents-eval-papers-meta-review.md
+++ b/_posts/2025-08-09-ai-agents-eval-papers-meta-review.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: AI Agents-eval Papers Meta Review
-excerpt: 
+excerpt: A meta-review of 50+ agentic AI evaluation papers identifying key dimensions — autonomy, multi-agent coordination, safety, and explainability — and critical gaps in standardization and long-term behavioral assessment.
 categories: [ml, ai, agents, eval]
 ---
 

--- a/_posts/2026-01-15-agentx-agentbeats-writeup.md
+++ b/_posts/2026-01-15-agentx-agentbeats-writeup.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title: GraphJudge: Measuring How Agents Collaborate
+excerpt: GraphJudge is an A2A-compliant multi-agent evaluation framework for the AgentBeats competition that captures interaction traces as directed graphs and scores coordination quality through structural graph metrics, LLM-as-judge qualitative assessment, and text similarity reproducibility checks.
+categories: [agents, eval, ml, ai]
+---
+
 # GraphJudge: Measuring How Agents Collaborate
 
 > Measure how, not just whether

--- a/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
+++ b/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
@@ -1,0 +1,109 @@
+---
+layout: post
+title: Building a Trustworthy Agent Loop for a Physical Lab
+excerpt: We build autonomous, self-evaluating agents — and we're building the hardest version of that idea: an open, sub-$1k self-driving lab. This is the thesis, the plan, and the one piece that already ships. The AI scientist's missing half is the agent, not the model.
+categories: [agents, ml, biolab, automation]
+---
+
+**TL;DR.** We build autonomous, self-evaluating agent systems. We are now building the hardest version of that idea — an open, sub-$1k self-driving lab whose goal is a closed `perceive → decide → act → record` loop an agent runs unattended. Being honest about stage is part of the point: today the **motion layer ships** (a working pipetting gantry, hardware-validated — [`i3mega-pipettebot`][pipettebot]) and our **software-side evaluation framework is real** ([`Agents-eval`][agents-eval]); the **closed, agent-decided loop is what we are building now** — not a result we are reporting. This post is the thesis and the plan, with the one piece that already works. The AI scientist's missing half is not the science model; it is the agent: autonomous enough to execute, trustworthy enough to believe.
+
+## The thesis
+
+Building an agent that plans and executes in software is tractable. The hard problems are downstream: Does the agent know when to stop? Can you verify its output without re-running the whole thing? When it fails, does it fail loudly or silently? Does your evaluation catch the difference between an agent that got lucky and one that actually learned?
+
+Software environments are forgiving. A physical lab is not — reagents run out, hardware drifts, a measurement that looks wrong might be wrong or the sensor might be. So the test we set ourselves is whether our agent loop — the same perceive, decide, act, record architecture we use in software — can be made to survive contact with a bench. That is the bet this project exists to settle.
+
+## What's real today
+
+We are deliberate about not reporting results we do not have. Two things are genuinely shipped:
+
+- **The motion layer.** [`i3mega-pipettebot`][pipettebot] turns a ~$150 repurposed 3D printer into a pipetting gantry, with real aspirate/dispense demonstrated on hardware (i3 Mega and Geeetech A30), 121 tests, and tagged releases. It moves a pipette to any well and dispenses. That part works.
+- **The evaluation discipline, on the software side.** [`Agents-eval`][agents-eval] is our multi-agent evaluation framework — objective, multi-tier scoring of agent outputs. Our "do not trust an agent you cannot evaluate" stance is already code there, not aspiration.
+
+A third piece is scaffold, and we will call it that: [`so101-biolab-automation`][so101] runs its workflow layer in software stub-mode and ships an eLabFTW client module — but its own README opens with "PROTOTYPE — hardware untested, CAD approximate." It is not a validated robot yet.
+
+## What we're building
+
+The self-driving lab is a build in progress. The target loop, with honest status on each link:
+
+```
+perceive  →  our vision tooling reads the dye signal per well           [building]
+decide    →  an agent picks the next pipetting volumes from the read    [the core build — does not exist yet]
+act       →  the gantry pipettes those volumes                          [shipped]
+record    →  reads + decisions stream to an eLabFTW notebook            [client exists; wiring it in is part of the build]
+            └─ repeat until the agent judges the plate converged        [the goal]
+```
+
+The honest center of gravity is the **decide** step — an agent that picks volumes live from measurements instead of running a script. It is the piece we are building, and it does not exist yet; the perception it would read from — our own vision tooling, [CellPlateVision][cpv] (image-based plate perception) or [vlm-toolkit][vlm] (a YOLO-to-GGUF-VLM pipeline, currently draft, pre-`v0.1.0`) — still has to be pointed at the dye readout and wired in. The closed loop has not run. Our target for a successful run is to converge a well to within ±5% of a dye-signal target in three or fewer iterations, unattended — the goal we are building toward, not a measured result.
+
+The testbed is food dye, read by camera: safe, vivid, fume-hood-free, and enough to prove the one thing that matters — that an agent can drive a measurement to a target without being told how. We are automation and agent engineers, not bench scientists; there are no drug-discovery claims here.
+
+## Why this is an agent problem, not a control problem
+
+Classical lab automation is scripted: you specify volumes, sequences, timing; the instrument executes. There is no decision — only execution.
+
+What we are building is different, and it is why we frame it as an agent problem. The volumes are not known in advance; the agent has to observe the plate, compute what to do next from what it measured, and decide when the plate has converged well enough to stop. That structure — observe, plan, act, self-evaluate, stop when done — is the same one we use in every other agent system we build. The lab just makes the stakes concrete: a wrong decision wastes reagent, time, and a plate well. There is no undo.
+
+## The questions we're designing the decide step around
+
+These are not solved; they are the design constraints we are building against:
+
+**When does the agent stop?** A premature stop wastes a plate; a late stop wastes reagent. The stopping condition has to be a judgment, not just a fixed threshold — "close enough" versus "converged."
+
+**How does it trust a measurement?** A single absorbance reading could be a bad drop, a bubble, or a real result. The agent should flag anomalies and request a re-read rather than accept noise as signal — hallucination detection, instantiated in hardware.
+
+**How do you evaluate the run?** This is where [`Agents-eval`][agents-eval] comes in: the discipline of scoring an agent's decision trace, not just its final answer, is the part of our software work we intend to carry directly onto the bench. Bringing per-run cost accounting across is the same kind of carry-over — intent informed by our software agents, not a feature of this lab yet.
+
+## Honest status
+
+To be unambiguous about maturity:
+
+- The **closed loop has not run** end-to-end. Today is the start of the build.
+- **Shipped:** the gantry motion library; the software-side evaluation framework.
+- **Building:** dye-signal perception (perceive) via our own vision tooling — [CellPlateVision][cpv] or [vlm-toolkit][vlm] (the latter draft, pre-`v0.1.0`) — the agent that decides volumes (decide), the integration connecting them, and ELN logging wired into the loop.
+- The `so101` arm hardware is an **untested prototype**; a private plate-reader REST wrapper (`wallac-victor2-api`) is planned for the remote-instrument path and not a verifiable claim here.
+- Run-level decision-trace scoring and per-iteration cost tracking are **disciplines we bring from our software work** — applying them to this lab is intent, not yet implemented here.
+
+## The gap we're building into
+
+If we close the loop, this is the space it fills — cheap, open, and *autonomous*, which is the combination nobody currently serves:
+
+| System                          | Cost           | Open-source | Autonomous decisions |
+| ------------------------------- | -------------- | ----------- | -------------------- |
+| Opentrons OT-2                  | from $15,950   | no          | no (scripted)        |
+| Science Jubilee + pipette       | ~$900+ build   | yes         | no                   |
+| **This stack (target)**         | **sub-$1k**    | **yes**     | **the build goal**   |
+
+Managed cloud labs clear five figures a year and are still scripted, not agent-autonomous. The cost and openness are already true of the shipped gantry; the *autonomous decisions* column is exactly what the build is for. (Opentrons figure is vendor list; Jubilee is a community build estimate; verify locally.)
+
+## Where this goes
+
+The proof point we are working toward is a single closed loop: one live convergence on a target, end-to-end and unattended, from a blank plate.
+
+The bigger picture: the AI-scientist conversation concentrates almost entirely on the science model — structure prediction, generative chemistry, literature synthesis. The infrastructure for that model to actually *do* science is largely missing. Running an experiment is not a single tool call; it is a multi-step agent problem with physical stakes, measurement noise, and decisions that need auditing after the fact.
+
+We are not building a drug-discovery pipeline. We are building the agent infrastructure a discovery pipeline would need — a loop that can plan an experiment, execute it on real hardware, evaluate its own output honestly, and report results an operator can trust. That is the problem we know how to work on. The lab is where we are testing whether our answer holds — and we will report what it does, not what we hoped.
+
+## Quick answers
+
+**Has the loop run yet?** No. The gantry ships and our evaluation framework is real; the closed, agent-decided loop is what we are building. We do not report results we do not have.
+
+**What is actually built?** The pipetting gantry (hardware-validated) and the software-side evaluation framework. The colorimeter and the decide-agent are the active build.
+
+**Is this drug discovery?** No — agent infrastructure. The testbed is food dye, not assays.
+
+**Why publish before it runs?** Because the thesis and the design are the point, and because being honest about stage is the same discipline we apply to agents.
+
+## Acknowledgements
+
+- The **Science Jubilee** community for the open-source liquid-handling reference.
+- **eLabFTW** for the open electronic lab notebook.
+- The **Marlin** firmware project — the unmodified target the gantry depends on.
+
+[agents-eval]: https://github.com/qte77/Agents-eval
+[pipettebot]: https://github.com/qte77/i3mega-pipettebot
+[so101]: https://github.com/qte77/so101-biolab-automation
+[cpv]: https://github.com/lambda-biolab/CellPlateVision
+[vlm]: https://github.com/qte77/vlm-toolkit
+[sj]: https://science-jubilee.readthedocs.io/en/latest/
+[ot2]: https://opentrons.com/products/ot-2-robot


### PR DESCRIPTION
## What

Three topic commits on the blog:

1. **Excerpts** — populate the empty `excerpt:` front-matter field on 19 existing posts. Improves SEO meta descriptions and Atom-feed summaries (`jekyll-seo-tag` consumes `excerpt`). Each is derived from the post's actual content; no overclaim.
2. **Front-matter fix** — two posts (`2024-06-08-SegFormerBaseline-FineTuning-results`, `2026-01-15-agentx-agentbeats-writeup`) had **no YAML front matter**, so Jekyll was not rendering them as posts. Added the standard 5-field block; the agentbeats post is now titled "GraphJudge: Measuring How Agents Collaborate".
3. **New post** — `Building a Trustworthy Agent Loop for a Physical Lab`: agent-first, and explicit about build stage (gantry + Agents-eval shipped; the closed perceive→decide→act→record loop is the active build, not a reported result).

## Notes

- `llms.txt` is CI-auto-generated (`gha-llms-txt-action`); it will regenerate to include the new post and updated excerpts on merge — not hand-edited here.
- The new post still carries two editorial items the author may want to revisit before/after merge: the competitor figures (mirrored from the live pipettebot post) and the "Honest status" framing.

Generated with Claude <noreply@anthropic.com>
