### PR TITLE
fix(blog): YAML front-matter colons breaking the build

### DIFF
--- a/_posts/2026-01-15-agentx-agentbeats-writeup.md
+++ b/_posts/2026-01-15-agentx-agentbeats-writeup.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: GraphJudge: Measuring How Agents Collaborate
+title: GraphJudge — Measuring How Agents Collaborate
 excerpt: GraphJudge is an A2A-compliant multi-agent evaluation framework for the AgentBeats competition that captures interaction traces as directed graphs and scores coordination quality through structural graph metrics, LLM-as-judge qualitative assessment, and text similarity reproducibility checks.
 categories: [agents, eval, ml, ai]
 ---

--- a/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
+++ b/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Building a Trustworthy Agent Loop for a Physical Lab
-excerpt: We build autonomous, self-evaluating agents — and we're building the hardest version of that idea: an open, sub-$1k self-driving lab. This is the thesis, the plan, and the one piece that already ships. The AI scientist's missing half is the agent, not the model.
+excerpt: We build autonomous, self-evaluating agents — and we're building the hardest version of that idea, an open sub-$1k self-driving lab. This is the thesis, the plan, and the one piece that already ships. The AI scientist's missing half is the agent, not the model.
 categories: [agents, ml, biolab, automation]
 ---
 


### PR DESCRIPTION
Two published posts failed the Jekyll YAML front-matter parse — an unquoted colon-space in a value reads as a nested mapping (`mapping values are not allowed in this context`):

- `2026-06-12-open-self-driving-lab-agent-loop.md` — excerpt `…that idea: an open…` → `…that idea, an open…`.
- `2026-01-15-agentx-agentbeats-writeup.md` — title `GraphJudge: Measuring…` → `GraphJudge — Measuring…` (body H1 keeps its colon; markdown, not YAML).

Kept the house convention (unquoted, colon-free scalars). Scanned all 25 posts' front matter — no other colon/structure issues remain.

Generated with Claude <noreply@anthropic.com>
