### PR TITLE
feat(blog): dark mode via prefers-color-scheme + EyeRest tokens (#8)

### DIFF
--- a/_sass/_darcula.scss
+++ b/_sass/_darcula.scss
@@ -12,8 +12,8 @@ code {
 }
 
 .highlighter-rouge {
-    background-color: #FAFAFA;
-    color: #FF554A;
+    background-color: var(--code-inline-bg);
+    color: var(--code-inline-text);
     font-size: 16px;
 }
 

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -16,15 +16,76 @@
 // Brand sans is Inter (see qte77/qte77 brand/DESIGN.md). Not self-hosted —
 // Inter-or-system per the design tokens, with the fallback stack below.
 
+// Theme tokens — qte77 EyeRest brand (qte77/qte77 brand/DESIGN.md). Light
+// defaults; the @media block flips to the dark scheme. Path A
+// (prefers-color-scheme); this CSS-var layer is also Path B's foundation.
+:root {
+  --bg: #ece8d8;
+  --surface: #e2dec8;
+  --border: #c8c4b0;
+  --text: #2c2818;
+  --muted: #625a3a;
+  --link: #705808;
+  --link-hover: #5a4806;
+  --selection-bg: #c8c4b0;
+  --selection-text: #2c2818;
+  --blockquote-bg: #ddd8c8;
+  --callout-bg: #d8e0c0;
+  --search-bg: #ece8d8;
+  --table-stripe: #ddd8c8;
+  --pagination-hover-bg: #d8d4c4;
+  --chip-bg: #d8d4c4;
+  --form-bg: #e2dec8;
+  --carbon-bg: #ece8d8;
+  --carbon-border: #c8c4b0;
+  --tag-bg: #4a6818;
+  --tag-text: #ece8d8;
+  --btn-subscribe-bg: rgba(0, 0, 0, 0.08);
+  --btn-subscribe-text: #2c2818;
+  --bar-bg: #705808;
+  --code-inline-bg: #e2dec8;
+  --code-inline-text: #983828;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1c1a14;
+    --surface: #242018;
+    --border: #383428;
+    --text: #d8d0b8;
+    --muted: #a89878;
+    --link: #c8a858;
+    --link-hover: #d8b868;
+    --selection-bg: #383428;
+    --selection-text: #d8d0b8;
+    --blockquote-bg: #2a2620;
+    --callout-bg: #20281c;
+    --search-bg: #1c1a14;
+    --table-stripe: #201e18;
+    --pagination-hover-bg: #2c2820;
+    --chip-bg: #2c2820;
+    --form-bg: #242018;
+    --carbon-bg: #1c1a14;
+    --carbon-border: #383428;
+    --tag-bg: #4a6818;
+    --tag-text: #ece8d8;
+    --btn-subscribe-bg: rgba(255, 255, 255, 0.08);
+    --btn-subscribe-text: #d8d0b8;
+    --bar-bg: #c8a858;
+    --code-inline-bg: #242018;
+    --code-inline-text: #ff554a;
+  }
+}
+
 html {
   font-size: 100%;
   height: 100%;
 }
 
 body {
-  background: #fff;
+  background: var(--bg);
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  color: #404040;
+  color: var(--text);
   line-height: 1.7;
   font-weight: 400;
   font-size: 18px;
@@ -40,7 +101,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  color: $darkerGray;
+  color: var(--text);
   font-weight: bold;
 
   line-height: 1.7;
@@ -71,7 +132,7 @@ h2 {
 	    vertical-align: middle;
 	    width: 46px;
 	    height: 1px;
-	    background: rgb(192, 211, 218);
+	    background: var(--border);
 	    margin: 0px 30px;
 	}
 }
@@ -82,7 +143,7 @@ h3 {
 
 h4 {
   font-size: 18px;
-  color: #222;
+  color: var(--text);
 }
 
 p {
@@ -94,26 +155,26 @@ table {
 }
 
 table tr {
-	border-top: 1px solid #cccccc;
-	background-color: white;
+	border-top: 1px solid var(--border);
+	background-color: var(--bg);
 	margin: 0;
 	padding: 0;
 }
 
 table tr:nth-child(2n) {
-	background-color: #f8f8f8;
+	background-color: var(--table-stripe);
 }
 
 table tr th {
 	font-weight: bold;
-	border: 1px solid #cccccc;
+	border: 1px solid var(--border);
 	text-align: left;
 	margin: 0;
 	padding: 6px 13px;
 }
 
 table tr td {
-	border: 1px solid #cccccc;
+	border: 1px solid var(--border);
 	text-align: left;
 	margin: 0;
 	padding: 6px 13px;
@@ -145,16 +206,16 @@ table tr td :last-child {
   padding: 12px 20px;
   margin: 8px 0;
   display: inline-block;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   border-radius: 4px;
   box-sizing: border-box;
   font-size: 18px;
-  background-color: #fff3ff;
+  background-color: var(--search-bg);
 }
 
 .share-box {
   font-weight: bold;
-  color: #222;
+  color: var(--text);
 }
 
 span[data-pullquote] {
@@ -173,16 +234,16 @@ span[data-pullquote]:before {
   padding: 0 -5% 0 0;
   font-size: 1.3em;
   font-style: italic;
-  color: green;
+  color: var(--link);
   text-align: center;
 }
 
 a {
-  color: $blue;
+  color: var(--link);
   text-decoration: none;
 	cursor: pointer;
   &:hover, &:active {
-    color: $blue;
+    color: var(--link);
   }
 }
 
@@ -232,17 +293,17 @@ p > img {
 
 .date {
   font-style: italic;
-  color: $gray;
+  color: var(--muted);
 }
 
 // Specify the color of the selection
 ::-moz-selection {
-  color: $black;
-  background: $lightGray;
+  color: var(--selection-text);
+  background: var(--selection-bg);
 }
 ::selection {
-  color: $black;
-  background: $lightGray;
+  color: var(--selection-text);
+  background: var(--selection-bg);
 }
 
 // Nicolas Gallagher's micro clearfix hack
@@ -271,7 +332,7 @@ p > img {
 
 .masthead {
   padding: 20px 0;
-  border-bottom: 1px solid $lightGray;
+  border-bottom: 1px solid var(--border);
 
   @include mobile {
     text-align: center;
@@ -307,7 +368,7 @@ p > img {
 
 .site-name {
   margin: 0;
-  color: $darkGray;
+  color: var(--text);
   cursor: pointer;
   font-family: $helveticaNeue;
   font-weight: 300;
@@ -322,7 +383,7 @@ p > img {
 
 .site-description {
   margin: -5px 0 0 0;
-  color: $gray;
+  color: var(--muted);
   font-size: 16px;
 
   @include mobile {
@@ -345,14 +406,14 @@ nav {
 
   a {
     margin-left: 20px;
-    color: $darkGray;
+    color: var(--text);
     text-align: right;
     font-weight: 300;
     letter-spacing: 1px;
 
     @include mobile {
       margin: 0 10px;
-      color: $blue;
+      color: var(--link);
     }
   }
 }
@@ -363,7 +424,7 @@ nav {
 
 .posts > .post {
   padding-bottom: 2em;
-  border-bottom: 1px solid $lightGray;
+  border-bottom: 1px solid var(--border);
 }
 
 .posts > .post:last-child {
@@ -376,20 +437,20 @@ nav {
     margin: 1.8em .8em;
     /*border-left: 2px solid $gray;*/
     padding: 0.1em 1em;
-    color: $gray;
+    color: var(--muted);
     font-size: 22px;
     font-style: italic;
-    background-color: #ede1ff;
+    background-color: var(--blockquote-bg);
   }
 
   .you-may-like{
     margin: 1.8em .8em;
     /*border-left: 2px solid $gray;*/
     padding: 0.1em 1em;
-    color: $gray;
+    color: var(--muted);
     font-size: 22px;
     font-style: italic;
-    background-color: #ddffb5;;
+    background-color: var(--callout-bg);;
   }
 
   .comments {
@@ -416,7 +477,7 @@ nav {
   bottom: 0;
   width: 100%;
   height: 89px;
-  background-color: $lightGray;
+  background-color: var(--surface);
 }
 
 footer {
@@ -435,7 +496,7 @@ body:after {
 }
 
 #bar {
-    background: #000;
+    background: var(--bar-bg);
     height: 7px;
     background-size: cover;
     background-position: left 60%;
@@ -466,17 +527,17 @@ body:after {
 
 .author_title{
   text-align: center;
-  color: #939aa1;
+  color: var(--muted);
   letter-spacing: 2px;
 }
 
 .post_date{
   text-align: center;
-  color: #939aa1;
+  color: var(--muted);
 }
 
 .cd-container a {
-  color: #30434e;
+  color: var(--link);
   text-decoration: none;
   font-family: "Open Sans", sans-serif;
 }
@@ -522,7 +583,7 @@ Modules - reusable parts of our design
   left: 18px;
   height: 100%;
   width: 4px;
-  background: #d7e4ed;
+  background: var(--border);
 }
 @media only screen and (min-width: 1170px) {
   #cd-timeline {
@@ -569,7 +630,7 @@ Modules - reusable parts of our design
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  box-shadow: 0 0 0 4px white, inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 0 0 4px var(--bg), inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
 }
 .cd-timeline-img img {
   display: block;
@@ -597,17 +658,17 @@ Modules - reusable parts of our design
     height: 32px;
     font-size: 14px;
     font-weight: 500;
-    color: rgba(0,0,0,.6);
+    color: var(--muted);
     line-height: 32px;
     padding: 0 12px;
     border-radius: 16px;
-    background-color: #e4e4e4;
+    background-color: var(--chip-bg);
     margin-bottom: 5px;
     margin-right: 5px;
 }
 
 .yellow.lighten-2 {
-    background-color: #efd3f9 !important;
+    background-color: var(--chip-bg) !important;
 }
 
 #gh-latest{
@@ -616,9 +677,9 @@ Modules - reusable parts of our design
 }
 
 .text-link {
-    color: #000;
+    color: var(--text);
     text-decoration: none;
-    border-bottom: 1px dotted #000;
+    border-bottom: 1px dotted var(--border);
 }
 
 //carbon ads
@@ -634,8 +695,8 @@ Modules - reusable parts of our design
   max-width: 270px;
   border-radius: 4px;
   text-align: center;
-  border: dashed 1px #e6e6e6;
-  background-color: hsl(0, 0%, 98%);
+  border: dashed 1px var(--carbon-border);
+  background-color: var(--carbon-bg);
   font-size: var(--font-size);
   line-height: 1.5;
   width: 100%;
@@ -701,24 +762,24 @@ Modules - reusable parts of our design
   font-size: 14.5px;
   padding: 2px 13px;
   border: none;
-  background-color: #4CAF50;
+  background-color: var(--tag-bg);
   border-radius: 50px;
-  color: #fff;
+  color: var(--tag-text);
 }
 
 .pagination a, .pagination span {
   padding: 7px 18px;
-  border: 1px solid #eee;
+  border: 1px solid var(--border);
   margin-left: -2px;
   margin-right: -2px;
-  background-color: #ffffff;
+  background-color: var(--bg);
   display: inline-block;
 }
 
 .pagination a {    
   &:hover {
-      background-color: #f1f1f1;
-      color: #333;
+      background-color: var(--pagination-hover-bg);
+      color: var(--text);
   }
 }
 
@@ -762,19 +823,21 @@ Modules - reusable parts of our design
 }
 
 .tlemail {
+  background-color: var(--bg);
+  color: var(--text);
   width: 80%;
   padding: 12px 20px;
   margin: 8px 0;
   display: inline-block;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   border-radius: 4px;
   box-sizing: border-box;
 }
 
 .subscribeBtn {
   width: 30%;
-  background-color: #4CAF50;
-  color: white;
+  background-color: var(--tag-bg);
+  color: var(--tag-text);
   padding: 14px 20px;
   margin: 8px 0;
   border: none;
@@ -784,10 +847,10 @@ Modules - reusable parts of our design
 }
 
 .tinyletterForm {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 3px;
   text-align: center;
-  background: #ececec;
+  background: var(--form-bg);
   margin: 8px;
   border-radius: 5px;
 }
@@ -795,7 +858,7 @@ Modules - reusable parts of our design
 .btn-subscribe {
   line-height: 20px;
   text-decoration: none;
-  background: #00000015;
+  background: var(--btn-subscribe-bg);
   border: none;
   font-size: 12px;
   padding: 0px 7px;
@@ -804,11 +867,11 @@ Modules - reusable parts of our design
   position: relative;
   top: -1px;
   margin-left: 5px;
-  color: black;
+  color: var(--btn-subscribe-text);
 }
 
 .btn-subscribe:hover {
-  color: black;
+  color: var(--btn-subscribe-text);
 }
 
 .btn-subscribe > svg {
@@ -899,10 +962,10 @@ Modules - reusable parts of our design
 .cd-timeline-content {
   position: relative;
   margin-left: 60px;
-  background: #e9f0f5;
+  background: var(--surface);
   border-radius: 0.25em;
   padding: 1em;
-  box-shadow: 0 3px 0 #d7e4ed;
+  box-shadow: 0 3px 0 var(--border);
 }
 .cd-timeline-content:after {
   content: "";
@@ -910,7 +973,7 @@ Modules - reusable parts of our design
   clear: both;
 }
 .cd-timeline-content h2 {
-  color: #303e49;
+  color: var(--text);
 }
 .cd-timeline-content p, .cd-timeline-content .cd-read-more, .cd-timeline-content .cd-date {
   font-size: 13px;
@@ -926,12 +989,12 @@ Modules - reusable parts of our design
 .cd-timeline-content .cd-read-more {
   float: right;
   padding: .8em 1em;
-  background: #acb7c0;
-  color: white;
+  background: var(--surface);
+  color: var(--text);
   border-radius: 0.25em;
 }
 .no-touch .cd-timeline-content .cd-read-more:hover {
-  background-color: #bac4cb;
+  background-color: var(--border);
 }
 .cd-timeline-content .cd-date {
   float: left;
@@ -946,7 +1009,7 @@ Modules - reusable parts of our design
   height: 0;
   width: 0;
   border: 7px solid transparent;
-  border-right: 7px solid white;
+  border-right: 7px solid var(--surface);
 }
 @media only screen and (min-width: 768px) {
   .cd-timeline-content h2 {
@@ -972,7 +1035,7 @@ Modules - reusable parts of our design
     top: 24px;
     left: 100%;
     border-color: transparent;
-    border-left-color: white;
+    border-left-color: var(--text);
   }
   .cd-timeline-content .cd-read-more {
     float: left;
@@ -993,7 +1056,7 @@ Modules - reusable parts of our design
     left: auto;
     right: 100%;
     border-color: transparent;
-    border-right-color: white;
+    border-right-color: var(--text);
   }
   .cd-timeline-block:nth-child(even) .cd-timeline-content .cd-read-more {
     float: right;


### PR DESCRIPTION
Closes part of #8 (Path A).

## What

Adds a `prefers-color-scheme` dark mode driven by a CSS-custom-property theme
layer sourced from the qte77 brand `DESIGN.md` (EyeRest tokens). No toggle UI or
JS — the `:root` var layer is simultaneously **Path B's first step** (a future
toggle just overrides the same vars via `[data-theme]`).

## How

- `:root { --bg, --text, --link, --border, ... }` light defaults +
  `@media (prefers-color-scheme: dark) { :root { ... } }` dark overrides.
- ~65 color usages across `assets/style.scss` and the `_darcula` inline-code
  rule remapped to semantic vars (page, text, links, nav, muted, selection,
  blockquote, callout, search, tags, tables, pagination, chips, forms, carbon,
  timeline, inline code).
- Darcula **fenced** code blocks intentionally stay dark in both schemes
  (GitHub/VS-Code-docs convention); only **inline** code (`.highlighter-rouge`)
  is themed.

## Verification (design workflow)

Built + adversarially verified by a multi-agent design pass (audit → map →
WCAG contrast + completeness critics). Contrast corrections baked in from the
verification: `--link #705808`, `--muted #625a3a`, differentiated `--link-hover`
— every text/bg pair targets WCAG AA in both schemes. **Not** rendered locally
(no Jekyll build here) — please eyeball the deployed preview.

## Deferred to Path B (documented)

- **Social SVG icons** — base64 `background-image` blobs can't be themed via CSS
  vars (need `mask-image` + `currentColor` or inline `<svg>`); they keep brand
  colors, so GitHub/Facebook marks are low-contrast on the dark bg.
- The decorative `body:after` brand gradient bar and the carbon-ads internal
  hatch stripe (cosmetic) are left as-is.

A follow-up (Path B) can add the system/dark/light toggle + the SVG-icon fix.

Generated with Claude <noreply@anthropic.com>