### PR TITLE
feat(blog): theme picker (auto/light/dark) + left-aligned homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,19 @@
     {% seo title=false %}
     {% include meta.html %}
 
+    <script>
+      // Apply the reader's saved theme before first paint to avoid a flash.
+      // "auto" stores nothing and falls back to prefers-color-scheme (CSS).
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (t === 'light' || t === 'dark') {
+            document.documentElement.setAttribute('data-theme', t);
+          }
+        } catch (e) {}
+      })();
+    </script>
+
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
     <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
@@ -34,6 +47,7 @@
               <a href="{{ site.baseurl }}/search">Search</a>
               <a href="{{ site.baseurl }}/about">About</a>
               <a href="{{ site.baseurl }}/archive">Archive</a>
+              <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Color theme">Auto</button>
             </nav>
           </header>
         </div>
@@ -54,6 +68,7 @@
       </div>
     </div>
 
+    <script src="{{ site.baseurl }}/assets/theme.js"></script>
     {% include analytics.html %}
   </body>
 </html>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -107,7 +107,6 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.7;
   margin: 1em 0 15px;
   padding: 0;
-  text-align: center;
 
   @include mobile {
     line-height: 1.4;
@@ -509,7 +508,7 @@ body:after {
 
 .post h1{
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  text-align: center;
+  text-align: left;
   font-weight: bold;
   font-kerning: auto;
   font-feature-settings: "kern","liga","dlig","hlig","cswh";
@@ -518,7 +517,7 @@ body:after {
 
 .page h1{
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  text-align: center;
+  text-align: left;
   font-weight: bold;
   font-kerning: auto;
   font-feature-settings: "kern","liga","dlig","hlig","cswh";
@@ -526,13 +525,13 @@ body:after {
 }
 
 .author_title{
-  text-align: center;
+  text-align: left;
   color: var(--muted);
   letter-spacing: 2px;
 }
 
 .post_date{
-  text-align: center;
+  text-align: left;
   color: var(--muted);
 }
 

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -16,10 +16,12 @@
 // Brand sans is Inter (see qte77/qte77 brand/DESIGN.md). Not self-hosted —
 // Inter-or-system per the design tokens, with the fallback stack below.
 
-// Theme tokens — qte77 EyeRest brand (qte77/qte77 brand/DESIGN.md). Light
-// defaults; the @media block flips to the dark scheme. Path A
-// (prefers-color-scheme); this CSS-var layer is also Path B's foundation.
-:root {
+// Theme tokens — qte77 EyeRest brand (qte77/qte77 brand/DESIGN.md).
+// Two paths: Path A follows the OS via prefers-color-scheme; Path B lets the
+// reader override it with the nav theme picker, which sets data-theme on
+// <html> (see assets/theme.js). The token sets live in mixins so both paths
+// and the manual overrides stay in sync.
+@mixin theme-light {
   --bg: #ece8d8;
   --surface: #e2dec8;
   --border: #c8c4b0;
@@ -47,35 +49,45 @@
   --code-inline-text: #983828;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #1c1a14;
-    --surface: #242018;
-    --border: #383428;
-    --text: #d8d0b8;
-    --muted: #a89878;
-    --link: #c8a858;
-    --link-hover: #d8b868;
-    --selection-bg: #383428;
-    --selection-text: #d8d0b8;
-    --blockquote-bg: #2a2620;
-    --callout-bg: #20281c;
-    --search-bg: #1c1a14;
-    --table-stripe: #201e18;
-    --pagination-hover-bg: #2c2820;
-    --chip-bg: #2c2820;
-    --form-bg: #242018;
-    --carbon-bg: #1c1a14;
-    --carbon-border: #383428;
-    --tag-bg: #4a6818;
-    --tag-text: #ece8d8;
-    --btn-subscribe-bg: rgba(255, 255, 255, 0.08);
-    --btn-subscribe-text: #d8d0b8;
-    --bar-bg: #c8a858;
-    --code-inline-bg: #242018;
-    --code-inline-text: #ff554a;
-  }
+@mixin theme-dark {
+  --bg: #1c1a14;
+  --surface: #242018;
+  --border: #383428;
+  --text: #d8d0b8;
+  --muted: #a89878;
+  --link: #c8a858;
+  --link-hover: #d8b868;
+  --selection-bg: #383428;
+  --selection-text: #d8d0b8;
+  --blockquote-bg: #2a2620;
+  --callout-bg: #20281c;
+  --search-bg: #1c1a14;
+  --table-stripe: #201e18;
+  --pagination-hover-bg: #2c2820;
+  --chip-bg: #2c2820;
+  --form-bg: #242018;
+  --carbon-bg: #1c1a14;
+  --carbon-border: #383428;
+  --tag-bg: #4a6818;
+  --tag-text: #ece8d8;
+  --btn-subscribe-bg: rgba(255, 255, 255, 0.08);
+  --btn-subscribe-text: #d8d0b8;
+  --bar-bg: #c8a858;
+  --code-inline-bg: #242018;
+  --code-inline-text: #ff554a;
 }
+
+:root { @include theme-light; }
+
+// Path A — follow the OS when the reader has not chosen.
+@media (prefers-color-scheme: dark) {
+  :root { @include theme-dark; }
+}
+
+// Path B — explicit reader choice (data-theme) wins over the OS via higher
+// specificity. "auto" simply removes the attribute and falls back to Path A.
+:root[data-theme="light"] { @include theme-light; }
+:root[data-theme="dark"]  { @include theme-dark; }
 
 html {
   font-size: 100%;
@@ -414,6 +426,28 @@ nav {
       margin: 0 10px;
       color: var(--link);
     }
+  }
+}
+
+.theme-toggle {
+  margin-left: 20px;
+  padding: 1px 10px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font: inherit;
+  font-size: 15px;
+  letter-spacing: 1px;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--link);
+    border-color: var(--link);
+  }
+
+  @include mobile {
+    margin: 0 10px;
   }
 }
 

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,45 @@
+// Theme picker: cycles auto -> light -> dark and remembers the choice.
+// "auto" follows the OS (prefers-color-scheme); light/dark set data-theme on
+// <html> to override it. Pairs with the theme-token mixins in style.scss and
+// the anti-flash inline script in _layouts/default.html.
+(function () {
+  var root = document.documentElement;
+  var btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+
+  var ORDER = ['auto', 'light', 'dark'];
+  var LABEL = { auto: 'Auto', light: 'Light', dark: 'Dark' };
+
+  function current() {
+    try {
+      var t = localStorage.getItem('theme');
+      return (t === 'light' || t === 'dark') ? t : 'auto';
+    } catch (e) {
+      return 'auto';
+    }
+  }
+
+  function apply(mode) {
+    if (mode === 'light' || mode === 'dark') {
+      root.setAttribute('data-theme', mode);
+    } else {
+      root.removeAttribute('data-theme');
+    }
+    try {
+      if (mode === 'auto') {
+        localStorage.removeItem('theme');
+      } else {
+        localStorage.setItem('theme', mode);
+      }
+    } catch (e) {}
+    btn.textContent = LABEL[mode];
+    btn.setAttribute('aria-label', 'Color theme: ' + LABEL[mode] + ' (click to change)');
+  }
+
+  apply(current());
+
+  btn.addEventListener('click', function () {
+    var next = ORDER[(ORDER.indexOf(current()) + 1) % ORDER.length];
+    apply(next);
+  });
+})();


### PR DESCRIPTION
Two topical commits:

1. **style(blog): left-align titles, dates, and headings** — fixes the inconsistent homepage where post titles and dates were centered over left-aligned header/excerpts. Now everything shares one left edge (nav stays right per the masthead).
2. **feat(blog): auto/light/dark theme picker (#8)** — adds a manual toggle on top of the existing prefers-color-scheme dark mode. Tokens move into theme-light/theme-dark mixins; an explicit `data-theme` on <html> overrides the OS via specificity; 'auto' falls back to the media query. Includes a nav button, an anti-flash head script, and `assets/theme.js` (cycles auto/light/dark, persists to localStorage).

Note: GitHub Pages has no PR preview, so the rendered result is verified post-merge against the live build. The SCSS is a straightforward mixin refactor; a failed Pages build would keep the last good deploy live.

Generated with Claude <noreply@anthropic.com>