### PR TITLE
style(blog): flush-right nav + theme toggle polish (icon+label)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
               <a href="{{ site.baseurl }}/search">Search</a>
               <a href="{{ site.baseurl }}/about">About</a>
               <a href="{{ site.baseurl }}/archive">Archive</a>
-              <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Color theme">Auto</button>
+              <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Color theme">◐ Auto</button>
             </nav>
           </header>
         </div>

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -433,14 +433,16 @@ nav {
 
 .theme-toggle {
   margin-left: 20px;
-  padding: 1px 10px;
+  padding: 2px 9px;
   background: transparent;
   border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--text);
   font: inherit;
   font-size: 15px;
+  font-weight: 300;
   letter-spacing: 1px;
+  line-height: 1.4;
   cursor: pointer;
 
   &:hover {

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -404,9 +404,11 @@ p > img {
 
 nav {
   float: right;
-  margin-top: 23px; // @TODO: Vertically middle align
+  margin-top: 23px;
   font-family: $helveticaNeue;
   font-size: 18px;
+  display: flex;
+  align-items: center;
 
   @include mobile {
     float: none;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -8,7 +8,7 @@
   if (!btn) return;
 
   var ORDER = ['auto', 'light', 'dark'];
-  var LABEL = { auto: 'Auto', light: 'Light', dark: 'Dark' };
+  var LABEL = { auto: '◐ Auto', light: '☀︎ Light', dark: '☾︎ Dark' };
 
   function current() {
     try {


### PR DESCRIPTION
Follow-up polish to the nav/theme work. Two topical commits:

1. **flush-right nav, vertically center items** — nav becomes a right-floated flex row (align-items:center) so links + toggle sit on one centered baseline, flush to the content's right edge.
2. **theme toggle icon+label + lighter styling** — each state shows a monochrome glyph (auto/light/dark) so it reads as a theme switch at a glance; toggle weight/padding tuned to sit within the nav.

GitHub Pages has no PR preview; verified post-merge against the live build.

Generated with Claude <noreply@anthropic.com>