### PR TITLE
feat(blog): SEO/GEO meta optimization (seo-tag config + dedup)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,17 +2,36 @@
 # This file contains configuration flags to customize your site
 #
 
-title: Recap on ML
+title: Recap on ML — AI Agents & Dev Tooling by qte77
 
 # Name of your site (displayed in the header)
 name: Recap on ML
 
-# Name of the author
-author: qte77
+# Author (hash form lets jekyll-seo-tag emit author JSON-LD + twitter:creator)
+author:
+  name: qte77
+  twitter: qte77
 
-# Short bio or description (displayed in the header AND used as SEO meta description)
-description: Notes on AI agents, ML, and dev tooling — by qte77
+# SEO meta description used by jekyll-seo-tag (120-160 chars)
+description: >-
+  Engineering notes by qte77 on AI agents, agentic dev infrastructure, ML
+  evaluation, GitHub Actions, and lab automation — practical, production-grade write-ups.
+
+# Short tagline shown in the site header (kept short on purpose)
+tagline: Notes on AI agents, ML, and dev tooling — by qte77
 lang: en
+
+# jekyll-seo-tag: Twitter Card + social + logo/image for richer OG and JSON-LD
+twitter:
+  username: qte77
+  card: summary
+social:
+  name: qte77
+  links:
+    - https://github.com/qte77
+logo: https://avatars.githubusercontent.com/u/93844790?v=4
+image: https://avatars.githubusercontent.com/u/93844790?v=4
+keywords: AI agents, machine learning, dev tooling, GitHub Actions, Claude Code, lab automation, qte77
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://avatars.githubusercontent.com/u/93844790?v=4 #/images/reverie.png

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,25 +1,14 @@
 <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
 <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0'>
+<meta name='format-detection' content='telephone=no'>
+<meta name='robots' content='index, follow'>
 
-{% if page.excerpt %}
-<meta property="og:description" content="{{ page.excerpt| strip_html }}" />
-{% elsif page.description %}
-<meta property="og:description" content="{{ page.description }}" />
-{% else %}
-<meta property="og:description" content="{{ site.description }}" />
-{% endif %}
-<meta name="author" content="{{ site.name }}" />
+{% comment %} OG, Twitter Card, canonical and JSON-LD are emitted by jekyll-seo-tag; only the tags it does not cover are kept here, to avoid duplicate meta tags. {% endcomment %}
 
-{% if page.title %}
-<meta property="og:title" content="{{ page.title }}" />
-<meta property="twitter:title" content="{{ page.title }}" />
-{% endif %}
+{% assign seo_author = page.author | default: site.author %}
+{% if seo_author.name %}<meta name='author' content='{{ seo_author.name }}'>
+{% elsif seo_author %}<meta name='author' content='{{ seo_author }}'>{% endif %}
 
-{% if page.image %}
-<meta property="og:image" content="{{ site.url }}{{ page.image }}"/>
-<meta property="twitter:image" content="{{ site.url }}{{ page.image }}"/>
-{% else %}
-<meta property="og:image" content="{{ site.url }}{{ site.avatar }}"/>
-<meta property="twitter:image" content="{{ site.url }}{{ site.avatar }}"/>
-{% endif %}
+{% assign seo_keywords = page.keywords | default: site.keywords %}
+{% if seo_keywords %}<meta name='keywords' content='{{ seo_keywords }}'>{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
+    <title>{% if page.title %}{{ page.title }} | {{ site.name }}{% else %}{{ site.title }}{% endif %}</title>
     {% seo title=false %}
     {% include meta.html %}
 
@@ -39,7 +39,7 @@
 
             <div class="site-info">
               <p class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></p>
-              <p class="site-description">{{ site.description }}</p> 
+              <p class="site-description">{{ site.tagline }}</p> 
             </div>
 
             <nav>

--- a/_posts/2026-06-01-pipettebot-sub-150-pipetting-robot.md
+++ b/_posts/2026-06-01-pipettebot-sub-150-pipetting-robot.md
@@ -1,7 +1,11 @@
 ---
 layout: post
 title: A $150 Pipetting Robot from a Stock 3D Printer
+description: >-
+  Build a 96-well pipetting robot for ~$150 from a used Anycubic i3 Mega and a
+  DLAB dPette+ — unmodified Marlin firmware, Python host control. Apache-2.0.
 excerpt: Turn a used Anycubic i3 Mega + a DLAB dPette+ electronic pipette into a 96-well disposable-tip pipetting robot. Marlin runs unmodified. Python drives. Apache-2.0.
+keywords: pipetting robot, lab automation, 3D printer hack, Anycubic i3 Mega, dPette, Marlin firmware, Python, biolab, open hardware
 categories: [biolab, automation, hardware, python]
 ---
 


### PR DESCRIPTION
Closes the seobility findings for the homepage and the pipettebot post, the DRY way.

Two topical commits:
1. Site-wide: configure jekyll-seo-tag (twitter card+username, social, logo, site image, author hash, keywords, 120-160 char description, longer brand title) so it emits OG/Twitter/canonical/JSON-LD correctly; remove the duplicate OG/Twitter/image tags from meta.html; keep only author/keywords/robots/format-detection; split a short header tagline from the SEO description; fix the over-long <title> template; drop viewport maximum-scale (WCAG 1.4.4).
2. Per-post: add description + keywords to the pipettebot post.

OG image falls back site-wide to the avatar (summary card) rather than an unverified per-post image. Verified post-merge against the live build.

Generated with Claude <noreply@anthropic.com>