### PR TITLE
fix(blog): author byline renders name, not the hash

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   <h1>{{ page.title }}</h1>
 
   <div>
-    <p class="author_title">{{site.author}}  ·  {{ page.date | date: "%B %e, %Y" }}</p>
+    <p class="author_title">{{ site.author.name | default: site.author }}  ·  {{ page.date | date: "%B %e, %Y" }}</p>
     {% if page.last_modified_at %}
     <p class="author_title" datetime="{{ page.last_modified_at | date_to_xmlschema }}">(Updated: {{ page.last_modified_at | date: "%b %-d, %Y" }})</p>
     {% endif %}


### PR DESCRIPTION
Regression from the SEO author-as-hash change: post.html printed the raw hash in the byline (e.g. {"name"=>"qte77", ...}). Use site.author.name with a scalar fallback.

Generated with Claude <noreply@anthropic.com>