### PR TITLE
style(blog): header polish - nav spacing, toggle glyphs, drop h2 rules

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -136,18 +136,6 @@ h2 {
   font-size: 24px;
 }
 
-@media (min-width: 769px){
-	.post .entry h2::before, .post .entry h2::after {
-	    content: "";
-	    display: inline-block;
-	    vertical-align: middle;
-	    width: 46px;
-	    height: 1px;
-	    background: var(--border);
-	    margin: 0px 30px;
-	}
-}
-
 h3 {
   font-size: 20px;
 }
@@ -462,7 +450,7 @@ p > img {
 
 nav {
   clear: both;
-  margin-top: 15px;
+  margin-top: 28px;
   font-family: $helveticaNeue;
   font-size: 18px;
   display: flex;

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -9,9 +9,10 @@
 
   var ORDER = ['auto', 'light', 'dark'];
   var WORD = { auto: 'Auto', light: 'Light', dark: 'Dark' };
-  // Decorative monochrome glyphs (text presentation via U+FE0E). The
-  // accessible name uses the word only, set via aria-label/title below.
-  var GLYPH = { auto: '◐', light: '☀︎', dark: '☾︎' };
+  // Monochrome geometric glyphs (Geometric Shapes block) that render reliably
+  // as text across fonts: half / hollow / filled circle. Decorative only --
+  // the accessible name uses the word via aria-label/title below.
+  var GLYPH = { auto: '◐', light: '○', dark: '●' };
 
   function current() {
     try {


### PR DESCRIPTION
Three follow-ups to the left-align work: drop the decorative h2 flank-lines (built for centered headings); swap toggle glyphs to reliable geometric circles (the sun fell back to a star); add nav breathing room below the tagline (margin-top 15->28px).

Generated with Claude <noreply@anthropic.com>