### PR TITLE
style(blog): more vspace above the nav

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -450,7 +450,7 @@ p > img {
 
 nav {
   clear: both;
-  margin-top: 28px;
+  margin-top: 44px;
   font-family: $helveticaNeue;
   font-size: 18px;
   display: flex;


### PR DESCRIPTION
Increase nav margin-top 28px -> 44px for a clearer gap below the header/tagline.

Generated with Claude <noreply@anthropic.com>