### PR TITLE
style(blog): real vspace above the nav via padding-top

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -450,7 +450,10 @@ p > img {
 
 nav {
   clear: both;
-  margin-top: 44px;
+  // margin-top is absorbed by clearance when the nav clears the floated
+  // masthead; use padding-top for a reliable gap above the menu.
+  margin-top: 0;
+  padding-top: 40px;
   font-family: $helveticaNeue;
   font-size: 18px;
   display: flex;


### PR DESCRIPTION
clear:both was absorbing the nav margin-top, so the earlier 15/28/44px bumps rendered identically. Switch to padding-top:40px for a reliable gap above the menu.

Generated with Claude <noreply@anthropic.com>