### PR TITLE
blog: cross-link agent-loop ↔ pipettebot posts + agent-loop SEO front matter

### DIFF
--- a/_posts/2026-06-01-pipettebot-sub-150-pipetting-robot.md
+++ b/_posts/2026-06-01-pipettebot-sub-150-pipetting-robot.md
@@ -100,8 +100,9 @@ acceleration via M203/M201/M204/M205 for liquid-handling-friendly moves.
 
 ## Companion tools
 
-A pipetting robot is one node in a wet-lab loop. Two siblings cover the
-gaps:
+A pipetting robot is one node in a wet-lab loop — the motion layer of a
+larger, still-in-progress [self-driving-lab agent loop][agent-loop-post].
+Two siblings cover the gaps:
 
 - [`so101-biolab-automation`][so101] — dual SO-101 robot arm that
   retrieves the used-tips bin from the deck after the i3 homes. The gantry
@@ -167,6 +168,7 @@ family from `M115` and dispatches per platform.
   depends on.
 
 [repo]: https://github.com/qte77/i3mega-pipettebot
+[agent-loop-post]: /open-self-driving-lab-agent-loop/
 [cycle-gif]: https://raw.githubusercontent.com/qte77/i3mega-pipettebot/main/assets/images/dpette%2Bi3_full_cycle.gif
 [driver]: https://github.com/Lambda-Biolab/dpette-usb-driver
 [so101]: https://github.com/qte77/so101-biolab-automation

--- a/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
+++ b/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
@@ -1,7 +1,11 @@
 ---
 layout: post
 title: Building a Trustworthy Agent Loop for a Physical Lab
+description: >-
+  An open, sub-$1k self-driving lab: an autonomous perceive→decide→act→record
+  agent loop on real lab hardware. The motion layer ships; the decide-agent is next.
 excerpt: We build autonomous, self-evaluating agents — and we're building the hardest version of that idea, an open sub-$1k self-driving lab. This is the thesis, the plan, and the one piece that already ships. The AI scientist's missing half is the agent, not the model.
+keywords: self-driving lab, autonomous agents, agent loop, lab automation, biolab, pipetting robot, agent evaluation, AI scientist, open hardware, qte77
 categories: [agents, ml, biolab, automation]
 ---
 

--- a/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
+++ b/_posts/2026-06-12-open-self-driving-lab-agent-loop.md
@@ -17,7 +17,7 @@ Software environments are forgiving. A physical lab is not — reagents run out,
 
 We are deliberate about not reporting results we do not have. Two things are genuinely shipped:
 
-- **The motion layer.** [`i3mega-pipettebot`][pipettebot] turns a ~$150 repurposed 3D printer into a pipetting gantry, with real aspirate/dispense demonstrated on hardware (i3 Mega and Geeetech A30), 121 tests, and tagged releases. It moves a pipette to any well and dispenses. That part works.
+- **The motion layer.** [`i3mega-pipettebot`][pipettebot] turns a ~$150 repurposed 3D printer into a pipetting gantry, with real aspirate/dispense demonstrated on hardware (i3 Mega and Geeetech A30), 121 tests, and tagged releases. It moves a pipette to any well and dispenses. That part works — [full build write-up][pipettebot-post].
 - **The evaluation discipline, on the software side.** [`Agents-eval`][agents-eval] is our multi-agent evaluation framework — objective, multi-tier scoring of agent outputs. Our "do not trust an agent you cannot evaluate" stance is already code there, not aspiration.
 
 A third piece is scaffold, and we will call it that: [`so101-biolab-automation`][so101] runs its workflow layer in software stub-mode and ships an eLabFTW client module — but its own README opens with "PROTOTYPE — hardware untested, CAD approximate." It is not a validated robot yet.
@@ -104,6 +104,7 @@ This lab is not the drug-discovery pipeline — that runs separately, in silico.
 
 [agents-eval]: https://github.com/qte77/Agents-eval
 [pipettebot]: https://github.com/qte77/i3mega-pipettebot
+[pipettebot-post]: /pipettebot-sub-150-pipetting-robot/
 [so101]: https://github.com/qte77/so101-biolab-automation
 [cpv]: https://github.com/lambda-biolab/CellPlateVision
 [vlm]: https://github.com/qte77/vlm-toolkit


### PR DESCRIPTION
Two topical commits:

1. **docs(blog): cross-link agent-loop and pipettebot posts** — bidirectional post-to-post reference links between the self-driving-lab agent-loop thesis and the pipettebot build write-up. Internal-linking / topical-cluster signal for SEO + answer-engine retrieval.
2. **chore(blog): add SEO description and keywords to agent-loop post** — front-matter parity with the pipettebot post (explicit jekyll-seo-tag meta description + keywords) instead of falling back to the long excerpt.

No body/content rewrites; links use root-relative URLs (baseurl `/`).

Generated with Claude <noreply@anthropic.com>