### PR TITLE
chore(style): drop unused legacy font-stack variables

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -14,11 +14,6 @@ $gray: #666;
 $lightGray: #eee;
 $white: #fff;
 
-// Font stacks
-$helvetica: Helvetica, Arial, sans-serif;
-$helveticaNeue: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$georgia: Georgia, serif;
-
 // Brand typefaces (self-hosted, see _fonts.scss)
 $sans: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;


### PR DESCRIPTION
Removes `$helvetica`, `$helveticaNeue`, and `$georgia` from _variables.scss — all unused after the brand-font migration (`$sans`/`$mono` replaced every usage). Verified zero references repo-wide; Sass compile validated locally (identical output).

Generated with Claude <noreply@anthropic.com>