### PR TITLE
docs: decouple from the upstream Reverie fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Types of changes:
 - Things to come
 - Move to new version section if completed
 
+## [1.0.0] - 2026-06-19
+
+Decoupled from the upstream Reverie fork into a standalone, first-party theme.
+
+### Added
+
+- EyeRest warm, zero-blue theme (light/dark) and self-hosted brand fonts (Inter + JetBrains Mono)
+- Per-post SEO/GEO front matter (description, keywords, OG images) and post-to-post cross-links
+- Agent-loop diagram (SVG hero + PNG OG card)
+
+### Changed
+
+- Reframed as a first-party theme; LICENSE adds a qte77 copyright alongside the original Reverie MIT notice
+
+### Removed
+
+- Unused Reverie/Jekyll-Now theme leftovers (default fonts, pullquote include, highlights partial, duplicate markdownlint config)
+
 ## [0.4.0] - 2022-08-04
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Amit Merchant
+Copyright (c) 2019 Amit Merchant (Reverie theme)
+Copyright (c) 2019-2026 qte77
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ bundle exec jekyll serve
 
 ## Theme
 
-Built on [Reverie](https://github.com/amitmerchant1990/reverie) (MIT) — a
-fork-friendly Jekyll theme by [Amit Merchant](https://www.amitmerchant.com).
+A custom theme — the EyeRest warm, zero-blue palette (light/dark), self-hosted
+brand fonts (Inter + JetBrains Mono), and bespoke SEO/GEO. Originally
+bootstrapped from [Reverie](https://github.com/amitmerchant1990/reverie) (MIT)
+by [Amit Merchant](https://www.amitmerchant.com), since heavily diverged.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,3 @@ This is a static Jekyll blog hosted on GitHub Pages. In-scope reports:
 - Repository configuration (workflow permissions, action SHAs, secrets exposure)
 - Site-served content (XSS via Markdown rendering, malicious redirects)
 - Dependency vulnerabilities not surfaced by Dependabot
-
-Out of scope: upstream theme issues — see
-[Reverie](https://github.com/amitmerchant1990/reverie).

--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,7 @@ footer-links:
 # For newer "GA4" analytics, use the following instead of the "UA" entry above
 #google_analytics_ga4: 
 
-# Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
+# Your website URL
 # Used for Sitemap.xml and your RSS feed
 url: https://qte77.github.io
 enforce_ssl: https://qte77.github.io
@@ -85,7 +85,7 @@ baseurl: "/"
 
 permalink: /:title/
 
-# The release of Jekyll Now that you're using
+# Theme version
 version: v1.2.0
 
 # Jekyll 3 now only supports Kramdown for Markdown


### PR DESCRIPTION
Reframes the repo as a standalone, first-party theme (heavily diverged from the 2019 Reverie fork), while retaining Reverie's MIT credit.

- **LICENSE** — adds a qte77 copyright line alongside the original Reverie MIT notice (theme derives from Reverie, so its notice stays).
- **README** — describes the custom EyeRest theme + self-hosted brand fonts; "originally bootstrapped from Reverie, since heavily diverged."
- **SECURITY** — drops the "upstream theme issues out of scope" punt (the theme is first-party now).
- **CHANGELOG** — adds a 1.0.0 decoupling entry summarizing the recent theme/SEO/cleanup work.
- **_config.yml** — removes stale Reverie/Jekyll-Now boilerplate comments.

Generated with Claude <noreply@anthropic.com>