### PR TITLE
docs: ralph-history ref, third-party NOTICE, CHANGELOG backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Decoupled from the upstream Reverie fork into a standalone, first-party theme.
 - EyeRest warm, zero-blue theme (light/dark) and self-hosted brand fonts (Inter + JetBrains Mono)
 - Per-post SEO/GEO front matter (description, keywords, OG images) and post-to-post cross-links
 - Agent-loop diagram (SVG hero + PNG OG card)
+- Posts: a $150 pipetting robot, a self-driving-lab agent loop, and an open agentic coding harness
 
 ### Changed
 
@@ -36,6 +37,48 @@ Decoupled from the upstream Reverie fork into a standalone, first-party theme.
 ### Removed
 
 - Unused Reverie/Jekyll-Now theme leftovers (default fonts, pullquote include, highlights partial, duplicate markdownlint config)
+
+## [0.11.0] - 2026-01-15
+
+### Added
+
+- AgentX / AgentBeats "GraphJudge" multi-agent evaluation write-up
+
+## [0.10.0] - 2025-08-09
+
+### Added
+
+- AI-agents evaluation trilogy: comprehensive analysis, enhancement recommendations, and papers meta-review
+
+## [0.9.0] - 2025-02-07
+
+### Added
+
+- AI agents tools list and AI coding tools list
+
+## [0.8.0] - 2024-06-08
+
+### Added
+
+- SegFormer fine-tuning baseline results
+
+## [0.7.0] - 2024-05-27
+
+### Added
+
+- ML tooling overview
+
+## [0.6.0] - 2024-05-05
+
+### Added
+
+- SegFormer series, parts 1–4 (description, PoC difficulties, quantization description, quantization difficulties)
+
+## [0.5.0] - 2023-08-06
+
+### Added
+
+- SegFormer part 0 — short intro and reasoning for quantization
 
 ## [0.4.0] - 2022-08-04
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,166 @@
+qte77.github.io
+Copyright (c) 2019-2026 qte77
+
+The site theme and code are licensed under the MIT License (see the LICENSE
+file) and originally derive from the Reverie Jekyll theme (MIT). This NOTICE
+reproduces the copyright notices and licenses of the third-party assets that the
+site bundles and serves. (Build-time Jekyll plugins — jekyll-seo-tag,
+jekyll-feed, jekyll-sitemap, jekyll-paginate — are declared dependencies
+installed separately, not redistributed here.)
+
+================================================================================
+Reverie theme — https://github.com/amitmerchant1990/reverie — MIT License
+================================================================================
+
+The site's theme (layouts, includes, SCSS) derives from Reverie.
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Amit Merchant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+simple-jekyll-search — https://github.com/christian-fei/Simple-Jekyll-Search — MIT License
+================================================================================
+
+assets/simple-jekyll-search.min.js (v1.7.2) is vendored and served by the
+search page.
+
+Copyright (c) 2015-2018 Christian Fei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+Inter and JetBrains Mono (fonts) — SIL Open Font License 1.1
+================================================================================
+
+The web fonts under fonts/ are vendored and served by the site:
+
+  fonts/Inter-Regular.woff2, fonts/Inter-Bold.woff2
+    Copyright (c) 2016 The Inter Project Authors
+    (https://github.com/rsms/inter)
+
+  fonts/JetBrainsMono-Regular.woff2, fonts/JetBrainsMono-Bold.woff2
+    Copyright (c) 2020 The JetBrains Mono Project Authors
+    (https://github.com/JetBrains/JetBrainsMono)
+
+Both are licensed under the SIL Open Font License, Version 1.1, reproduced below
+and also available with a FAQ at https://openfontlicense.org.
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to any
+document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/_posts/2026-06-19-open-agentic-coding-harness.md
+++ b/_posts/2026-06-19-open-agentic-coding-harness.md
@@ -19,7 +19,7 @@ categories: [agents, ai, eval, tooling]
 
 The spine is a Bash-driven autonomous loop. [`ralph-loop-cc-tdd-wt-vibe-kanban-template`][ralph] picks the next story from a `prd.json`, drives Claude Code through a **Red → Green → Refactor** cycle (it refuses to mark a story done without a failing-test `[RED]` commit before the `[GREEN]` implementation), runs `make validate`, retries up to three times, and loops until every story passes. With `N_WT > 1` it runs several agents **in parallel git worktrees**, scores each result (stories passed, test count, coverage, lint penalties), and squash-merges the best — optionally with a Claude-as-judge pass and human approval. A `LEARNINGS.md` is appended after every story and re-read before the next, so knowledge compounds across the run. An optional Vibe Kanban board shows story status live.
 
-It's Geoffrey Huntley's ["Ralph" technique][ralph-technique] wired to Claude Code, TDD discipline, and worktree isolation. **Created 2026-01-18** — the first piece, and the center of everything below.
+It's Geoffrey Huntley's ["Ralph" technique][ralph-technique] — HumanLayer wrote up [a brief history of Ralph][ralph-history] — wired to Claude Code, TDD discipline, and worktree isolation. **Created 2026-01-18** — the first piece, and the center of everything below.
 
 ## The plugins — `claude-code-plugins`
 
@@ -120,5 +120,6 @@ A clean read: build the **loop** (Jan), **arm** it (Feb), then in a single March
 [office-forge]: https://github.com/qte77/office-forge-orchestrator
 [job-kit]: https://github.com/qte77/agentic-job-offer-to-application-kit
 [ralph-technique]: https://ghuntley.com/ralph/
+[ralph-history]: https://www.hlyr.dev/blog/brief-history-of-ralph
 [eval-posts]: /ai-agents-eval-comprehensive-analysis/
 [agentbeats-post]: /agentx-agentbeats-writeup/


### PR DESCRIPTION
Three topical commits:

1. **post** — links HumanLayer's [brief history of Ralph](https://www.hlyr.dev/blog/brief-history-of-ralph) in the agentic-harness post.
2. **NOTICE** — new file (paperverse-style) reproducing the licenses of the third-party assets the site bundles/serves: Reverie theme (MIT), simple-jekyll-search (MIT), and the self-hosted Inter + JetBrains Mono fonts (SIL OFL 1.1). The OFL requires the notice + license to accompany the redistributed fonts.
3. **CHANGELOG** — backfills 0.5.0–0.11.0 for the post batches un-logged since 2022 (SegFormer, ML tooling, tool lists, agents-eval trilogy, AgentBeats) and folds the three June-2026 posts into 1.0.0.

Generated with Claude <noreply@anthropic.com>